### PR TITLE
Added recipient ignore list feature

### DIFF
--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -2,7 +2,7 @@
 //
 //  $Id: spamass-milter.cpp,v 1.100 2014/08/15 02:46:50 kovert Exp $
 //
-//  SpamAss-Milter 
+//  SpamAss-Milter
 //    - a rather trivial SpamAssassin Sendmail Milter plugin
 //
 //  for information about SpamAssassin please see
@@ -12,22 +12,22 @@
 //                        http://www.sendmail.org
 //
 //  Copyright (c) 2002 Georg C. F. Greve <greve@gnu.org>,
-//   all rights maintained by FSF Europe e.V., 
+//   all rights maintained by FSF Europe e.V.,
 //   Villa Vogelsang, Antonienallee 1, 45279 Essen, Germany
 //
 
-// {{{ License, Contact, Notes & Includes 
+// {{{ License, Contact, Notes & Includes
 
 //   This program is free software; you can redistribute it and/or modify
 //   it under the terms of the GNU General Public License as published by
 //   the Free Software Foundation; either version 2 of the License, or
 //   (at your option) any later version.
-//  
+//
 //   This program is distributed in the hope that it will be useful,
 //   but WITHOUT ANY WARRANTY; without even the implied warranty of
 //   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //   GNU General Public License for more details.
-//  
+//
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
 //   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -63,7 +63,7 @@
 //    -- wait for mail to show up -- (restart at 3)
 //
 
-// Includes  
+// Includes
 #include "config.h"
 
 #include <arpa/inet.h>
@@ -107,11 +107,11 @@ extern "C" {
 
 #if !HAVE_DECL_STRSEP
 char *strsep(char **stringp, const char *delim);
-#endif 
+#endif
 
 #if !HAVE_DECL_DAEMON
 int daemon(int nochdir, int noclose);
-#endif 
+#endif
 
 #ifdef  __cplusplus
 }
@@ -127,7 +127,7 @@ int daemon(int nochdir, int noclose);
 #define INADDR_LOOPBACK 0x7F000001
 #endif
 
-// }}} 
+// }}}
 
 static const char Id[] = "$Id: spamass-milter.cpp,v 1.100 2014/08/15 02:46:50 kovert Exp $";
 
@@ -329,7 +329,7 @@ main(int argc, char* argv[])
       cout << "   -x: pass email address through alias and virtusertable expansion." << endl;
       cout << "   -a: don't scan messages over an authenticated connection." << endl;
       cout << "   -- spamc args: pass the remaining flags to spamc." << endl;
-              
+
       exit(EX_USAGE);
    }
 
@@ -356,7 +356,7 @@ main(int argc, char* argv[])
     }
 
 
-    if (dofork == true) 
+    if (dofork == true)
     {
         if (daemon(0, 0) == -1)
         {
@@ -364,14 +364,14 @@ main(int argc, char* argv[])
             exit(1);
         }
     }
-    
+
     if (pidfile)
     {
         fprintf(pidfile, "%ld\n", (long)getpid());
         fclose(pidfile);
         pidfile = NULL;
-    }    
-    
+    }
+
    {
       struct stat junk;
       if (stat(sock,&junk) == 0) unlink(sock);
@@ -435,7 +435,7 @@ void update_or_insert(SpamAssassin* assassin, SMFICTX* ctx, string oldstring, t_
 	debug(D_UORI, "u_or_i: newstring: <%s>", newstring.c_str());
 
 	oldsize = callsetter(*assassin,setter)(newstring);
-      
+
 	if (!dontmodify)
 	{
 		if (newstring != oldstring)
@@ -445,7 +445,7 @@ void update_or_insert(SpamAssassin* assassin, SMFICTX* ctx, string oldstring, t_
 			if (oldsize > 0)
 			{
 				debug(D_UORI, "u_or_i: changing");
-				smfi_chgheader(ctx, const_cast<char*>(header), 1, newstring.size() > 0 ? 
+				smfi_chgheader(ctx, const_cast<char*>(header), 1, newstring.size() > 0 ?
 					cstr : NULL );
 			} else if (newstring.size() > 0)
 			{
@@ -464,7 +464,7 @@ void update_or_insert(SpamAssassin* assassin, SMFICTX* ctx, string oldstring, t_
 //
 // implement the changes suggested by SpamAssassin for the mail.  Returns
 // the milter error code.
-int 
+int
 assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 {
   // find end of header (eol in last line of header)
@@ -500,7 +500,7 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 		}
 		if (rv != 1)
 			debug(D_ALWAYS, "Could not extract score from <%s>", spam_status);
-		else 
+		else
 		{
 			debug(D_MISC, "SA score: %d", score);
 			if (score >= reject_score)
@@ -526,7 +526,7 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 			popen_argv[0] = path_to_sendmail;
 			popen_argv[1] = spambucket;
 			popen_argv[2] = NULL;
-			
+
 			debug(D_COPY, "calling %s %s", path_to_sendmail, spambucket);
 			p = popenv(popen_argv, "w", &pid);
 			if (!p)
@@ -576,12 +576,12 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
   update_or_insert(assassin, ctx, assassin->spam_level(), &SpamAssassin::set_spam_level, "X-Spam-Level");
   update_or_insert(assassin, ctx, assassin->spam_checker_version(), &SpamAssassin::set_spam_checker_version, "X-Spam-Checker-Version");
 
-  // 
+  //
   // If SpamAssassin thinks it is spam, replace
   //  Subject:
   //  Content-Type:
   //  <Body>
-  // 
+  //
   //  However, only issue the header replacement calls if the content has
   //  actually changed. If SA didn't change subject or content-type, don't
   //  replace here unnecessarily.
@@ -595,7 +595,7 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
       string body=assassin->d().substr(bob, string::npos);
       if ( smfi_replacebody(ctx, (unsigned char *)body.c_str(), body_size) == MI_FAILURE )
 	throw string("error. could not replace body.");
-      
+
     }
 
   return SMFIS_CONTINUE;
@@ -668,7 +668,7 @@ retrieve_field(const string& header, const string& field)
   	field_end--;
 
   string data = header.substr( field_start, field_end - field_start );
-  
+
   /* Replace all CRLF pairs with LF */
   idx = 0;
   while ( (idx = data.find("\r\n", idx)) != string::npos )
@@ -688,10 +688,10 @@ retrieve_field(const string& header, const string& field)
 // Gets called once when a client connects to sendmail
 //
 // gets the originating IP address and checks it against the ignore list
-// if it isn't in the list, store the IP in a structure and store a 
+// if it isn't in the list, store the IP in a structure and store a
 // pointer to it in the private data area.
 //
-sfsistat 
+sfsistat
 mlfi_connect(SMFICTX * ctx, char *hostname, _SOCK_ADDR * hostaddr)
 {
 	struct context *sctx;
@@ -705,7 +705,7 @@ mlfi_connect(SMFICTX * ctx, char *hostname, _SOCK_ADDR * hostaddr)
 	if (!hostaddr)
 	{
 		static struct sockaddr_in localhost;
-		
+
 		/* not a socket; probably a local user calling sendmail directly */
 		/* set to 127.0.0.1 */
 		strcpy(sctx->connect_ip, "127.0.0.1");
@@ -762,7 +762,7 @@ mlfi_connect(SMFICTX * ctx, char *hostname, _SOCK_ADDR * hostaddr)
 		debug(D_FUNC, "mlfi_connect: exit ignore");
 		return SMFIS_ACCEPT;
 	}
-	
+
 	// Tell Milter to continue
 	debug(D_FUNC, "mlfi_connect: exit");
 
@@ -805,7 +805,7 @@ mlfi_envfrom(SMFICTX* ctx, char** envfrom)
   /* debug(D_ALWAYS, "ZZZ got private context %p", sctx); */
 
   if (auth) {
-    const char *auth_type = smfi_getsymval(ctx,  
+    const char *auth_type = smfi_getsymval(ctx,
         const_cast<char *>("{auth_type}"));
 
     if (auth_type) {
@@ -823,7 +823,7 @@ mlfi_envfrom(SMFICTX* ctx, char** envfrom)
       throw_error(problem);
       return SMFIS_TEMPFAIL;
     };
-  
+
   assassin->set_connectip(string(sctx->connect_ip));
 
   // Store a pointer to the assassin object in our context struct
@@ -899,7 +899,7 @@ mlfi_envrcpt(SMFICTX* ctx, char** envrcpt)
 		char buf[1024];
 		char *popen_argv[4];
 		pid_t pid;
-		
+
 		popen_argv[0] = path_to_sendmail;
 		popen_argv[1] = (char *)"-bv";
 		popen_argv[2] = envrcpt[0];
@@ -941,7 +941,7 @@ mlfi_envrcpt(SMFICTX* ctx, char** envrcpt)
 	} else
 	{
 		assassin->expandedrcpt.push_back(envrcpt[0]);
-	}	
+	}
 	debug(D_RCPT, "Total of %d actual recipients", (int)assassin->expandedrcpt.size());
 
 	if (assassin->numrcpt() == 0)
@@ -951,7 +951,7 @@ mlfi_envrcpt(SMFICTX* ctx, char** envrcpt)
 		   whitelist checks.  Also forge as complete a dummy
 		   Received: header as possible because SA gets a lot of
 		   info from it.
-		   
+
 			HReceived: $?sfrom $s $.$?_($?s$|from $.$_)
 				$.$?{auth_type}(authenticated$?{auth_ssf} bits=${auth_ssf}$.)
 				$.by $j ($v/$Z)$?r with $r$. id $i$?{tls_version}
@@ -959,7 +959,7 @@ mlfi_envrcpt(SMFICTX* ctx, char** envrcpt)
 				for $u; $|;
 				$.$b$?g
 				(envelope-from $g)$.
-		   
+
 		*/
 		const char *macro_b, *macro_i, *macro_j, *macro_r,
 		           *macro_s, *macro_v, *macro_Z, *macro__,
@@ -968,7 +968,7 @@ mlfi_envrcpt(SMFICTX* ctx, char** envrcpt)
 
 		/* RFC 822 date. */
 		macro_b = smfi_getsymval(ctx, const_cast<char *>("b"));
-		if (!macro_b)                                  
+		if (!macro_b)
 		{
 			time_t tval;
 			time(&tval);
@@ -1097,7 +1097,7 @@ mlfi_header(SMFICTX* ctx, char* headerf, char* headerv)
        try {
          assassin->connected = 1; // SPAMC is getting ready to run
          assassin->Connect();
-       } 
+       }
        catch (string& problem) {
          throw_error(problem);
          ((struct context *)smfi_getpriv(ctx))->assassin=NULL;
@@ -1130,7 +1130,7 @@ mlfi_header(SMFICTX* ctx, char* headerf, char* headerv)
       	/* Hm. X-Spam header, but not one we recognize.  Pass it through. */
       	suppress = 0;
       }
-      
+
       if (suppress)
       {
 	debug(D_FUNC, "mlfi_header: suppress");
@@ -1148,7 +1148,7 @@ mlfi_header(SMFICTX* ctx, char* headerf, char* headerv)
 
   // assemble header to be written to SpamAssassin
   string header = string(headerf) + ": " + headerv + "\r\n";
- 
+
   try {
     // write to SpamAssassin client
     assassin->output(header.c_str(),header.size());
@@ -1160,14 +1160,14 @@ mlfi_header(SMFICTX* ctx, char* headerf, char* headerv)
       debug(D_FUNC, "mlfi_header: exit error output");
       return SMFIS_TEMPFAIL;
     };
-  
+
   // go on...
   debug(D_FUNC, "mlfi_header: exit");
 
   return SMFIS_CONTINUE;
 }
 
-// 
+//
 // Gets called once when the header is finished.
 //
 // writes empty line to SpamAssassin client to separate
@@ -1186,7 +1186,7 @@ mlfi_eoh(SMFICTX* ctx)
        try {
          assassin->connected = 1; // SPAMC is getting ready to run
          assassin->Connect();
-       } 
+       }
        catch (string& problem) {
          throw_error(problem);
          ((struct context *)smfi_getpriv(ctx))->assassin=NULL;
@@ -1205,11 +1205,11 @@ mlfi_eoh(SMFICTX* ctx)
       throw_error(problem);
       ((struct context *)smfi_getpriv(ctx))->assassin=NULL;
       delete assassin;
-  
+
       debug(D_FUNC, "mlfi_eoh: exit error output");
       return SMFIS_TEMPFAIL;
     };
-  
+
   // go on...
 
   debug(D_FUNC, "mlfi_eoh: exit");
@@ -1227,7 +1227,7 @@ mlfi_body(SMFICTX* ctx, u_char *bodyp, size_t bodylen)
   debug(D_FUNC, "mlfi_body: enter");
   SpamAssassin* assassin = ((struct context *)smfi_getpriv(ctx))->assassin;
 
- 
+
   try {
     assassin->output(bodyp, bodylen);
   } catch (string& problem)
@@ -1256,7 +1256,7 @@ mlfi_eom(SMFICTX* ctx)
 {
   SpamAssassin* assassin = ((struct context *)smfi_getpriv(ctx))->assassin;
   int milter_status;
- 
+
   debug(D_FUNC, "mlfi_eom: enter");
   try {
 
@@ -1280,7 +1280,7 @@ mlfi_eom(SMFICTX* ctx)
       debug(D_FUNC, "mlfi_eom: exit error");
       return SMFIS_TEMPFAIL;
     };
-  
+
   // go on...
   debug(D_FUNC, "mlfi_eom: exit");
   return milter_status;
@@ -1341,7 +1341,7 @@ mlfi_abort(SMFICTX* ctx)
 // {{{ SpamAssassin Class
 
 //
-// This is a new constructor for the SpamAssassin object.  It simply 
+// This is a new constructor for the SpamAssassin object.  It simply
 // initializes two variables.  The original constructor has been
 // renamed to Connect().
 //
@@ -1355,8 +1355,8 @@ SpamAssassin::SpamAssassin():
 
 
 SpamAssassin::~SpamAssassin()
-{ 
-	if (connected) 
+{
+	if (connected)
 	{
 		// close all pipes that are still open
 		if (pipe_io[0][0] > -1)	close(pipe_io[0][0]);
@@ -1380,12 +1380,12 @@ SpamAssassin::~SpamAssassin()
     }
 
 	// Clean up the recip list. Might be overkill, but it's good housekeeping.
-	while( !recipients.empty()) 
+	while( !recipients.empty())
 	{
 		recipients.pop_front();
 	}
 	// Clean up the recip list. Might be overkill, but it's good housekeeping.
-	while( !expandedrcpt.empty()) 
+	while( !expandedrcpt.empty())
 	{
 		expandedrcpt.pop_front();
 	}
@@ -1415,7 +1415,7 @@ void SpamAssassin::Connect()
       break;
     case 0:
       // +++ CHILD +++
-      
+
       // close unused pipes
       close(pipe_io[1][0]);
       close(pipe_io[0][1]);
@@ -1427,14 +1427,14 @@ void SpamAssassin::Connect()
 
       closeall(3);
 
-      // execute spamc 
-      // absolute path (determined in autoconf) 
+      // execute spamc
+      // absolute path (determined in autoconf)
       // should be a little more secure
       // XXX arbitrary 100-argument max
       int argc = 0;
       char** argv = (char**) malloc(100*sizeof(char*));
       argv[argc++] = strdup(SPAMC);
-      if (flag_sniffuser) 
+      if (flag_sniffuser)
       {
         argv[argc++] = strdup("-u");
         if ( expandedrcpt.size() != 1 )
@@ -1443,23 +1443,23 @@ void SpamAssassin::Connect()
           // username to SPAMC.  This way special rules can be defined for
           // multi recipient messages.
           debug(D_RCPT, "%d recipients; spamc gets default username %s", (int)expandedrcpt.size(), defaultuser);
-          argv[argc++] = defaultuser; 
+          argv[argc++] = defaultuser;
         } else
-        { 
+        {
           // There is only 1 recipient so we pass the username
-          // (converted to lowercase) to SPAMC.  Don't worry about 
+          // (converted to lowercase) to SPAMC.  Don't worry about
           // freeing this memory as we're exec()ing anyhow.
           if (flag_full_email)
-            argv[argc] = strlwr(strdup(full_user().c_str())); 
+            argv[argc] = strlwr(strdup(full_user().c_str()));
           else
-            argv[argc] = strlwr(strdup(local_user().c_str())); 
+            argv[argc] = strlwr(strdup(local_user().c_str()));
 
           debug(D_RCPT, "spamc gets %s", argv[argc]);
-         
+
           argc++;
         }
       }
-      if (spamdhost) 
+      if (spamdhost)
       {
         argv[argc++] = strdup("-d");
         argv[argc++] = spamdhost;
@@ -1521,7 +1521,7 @@ SpamAssassin::output(const void* buffer, long size)
   /* If we haven't launched spamc yet, just store the data */
   if (!connected)
   {
-	/* Silly C++ can't tell the difference between 
+	/* Silly C++ can't tell the difference between
 		(const char*, string::size_type) and
 		(string::size_type, char), so we have to cast the parameters.
 	*/
@@ -1579,8 +1579,8 @@ SpamAssassin::output(const void* buffer, long size)
 			// close the pipes
 			close(pipe_io[0][1]);
 			close(pipe_io[1][0]);
-			pipe_io[0][1]=-1;	
-			pipe_io[1][0]=-1;	
+			pipe_io[0][1]=-1;
+			pipe_io[1][0]=-1;
 
 			// Slaughter child
 			kill(pid, SIGKILL);
@@ -1588,11 +1588,11 @@ SpamAssassin::output(const void* buffer, long size)
 			// set flags
 			error = true;
 			running = false;
-	
+
 			// wait until child is dead
 			waitpid(pid, &status, 0);
 
-			throw string(string("write error: ")+reason);	
+			throw string(string("write error: ")+reason);
 			break;
 	      default:
 			total += wsize;
@@ -1638,7 +1638,7 @@ SpamAssassin::input()
 
   // keep reading from input pipe until it is empty
   empty_and_close_pipe();
-  
+
   // that's it, we're through
   running = false;
 
@@ -1648,14 +1648,14 @@ SpamAssassin::input()
     {
       error = true;
       throw string(string("waitpid error: ")+string(strerror(errno)));
-    }; 
+    };
 	debug(D_FUNC, "::input exit2");
 }
 
 //
 // return reference to mail
 //
-string& 
+string&
 SpamAssassin::d()
 {
   return mail;
@@ -1664,49 +1664,49 @@ SpamAssassin::d()
 //
 // get values of the different SpamAssassin fields
 //
-string& 
+string&
 SpamAssassin::spam_status()
 {
   return x_spam_status;
 }
 
-string& 
+string&
 SpamAssassin::spam_flag()
 {
   return x_spam_flag;
 }
 
-string& 
+string&
 SpamAssassin::spam_report()
 {
   return x_spam_report;
 }
 
-string& 
+string&
 SpamAssassin::spam_prev_content_type()
 {
   return x_spam_prev_content_type;
 }
 
-string& 
+string&
 SpamAssassin::spam_checker_version()
 {
   return x_spam_checker_version;
 }
 
-string& 
+string&
 SpamAssassin::spam_level()
 {
   return x_spam_level;
 }
 
-string& 
+string&
 SpamAssassin::content_type()
 {
   return _content_type;
 }
 
-string& 
+string&
 SpamAssassin::subject()
 {
   return _subject;
@@ -1853,7 +1853,7 @@ SpamAssassin::set_rcpt(const string& val)
 {
   string::size_type old = _rcpt.size();
   _rcpt = val;
-  return (old);  
+  return (old);
 }
 
 string::size_type
@@ -1861,7 +1861,7 @@ SpamAssassin::set_from(const string& val)
 {
   string::size_type old = _from.size();
   _from = val;
-  return (old);  
+  return (old);
 }
 
 string::size_type
@@ -1869,7 +1869,7 @@ SpamAssassin::set_connectip(const string& val)
 {
   string::size_type old = _connectip.size();
   _connectip = val;
-  return (old);  
+  return (old);
 }
 
 //
@@ -1895,23 +1895,23 @@ SpamAssassin::read_pipe()
 
 	if (size < 0)
     {
-		// Error. 
+		// Error.
 		reason = string(strerror(errno));
-		
+
 		// Close remaining pipe.
 		close(pipe_io[1][0]);
 		pipe_io[1][0] = -1;
-	
+
 		// Slaughter child
 		kill(pid, SIGKILL);
-	
+
 		// set flags
 		error = true;
 		running = false;
-	
+
 		// wait until child is dead
 		waitpid(pid, &status, 0);
-	
+
 		// throw the error message that caused this trouble
 		throw string(string("read error: ")+reason);
 	} else if ( size == 0 )
@@ -1921,10 +1921,10 @@ SpamAssassin::read_pipe()
 		if(close(pipe_io[1][0]))
 			throw string(string("close error: ")+string(strerror(errno)));
 		pipe_io[1][0] = -1;
-	
+
 	} else
-	{ 
-		// append to mail buffer 
+	{
+		// append to mail buffer
 		mail.append(iobuff, size);
 		debug(D_POLL, "read %ld bytes", size);
 		debug(D_SPAMC, "input  \"%*.*s\"", (int)size, (int)size, iobuff);
@@ -2048,13 +2048,13 @@ void debug(enum debuglevel level, const char* fmt, ...)
 		syslog(LOG_ERR, "%s", buf);
 #if defined(HAVE_VASPRINTF)
 		free(buf);
-#endif 
+#endif
 #endif /* vsyslog */
 	}
 }
 
-// case-insensitive search 
-string::size_type 
+// case-insensitive search
+string::size_type
 find_nocase(const string& array, const string& pattern, string::size_type start)
 {
   string::size_type pos(start);
@@ -2073,7 +2073,7 @@ find_nocase(const string& array, const string& pattern, string::size_type start)
 	    return pos;
 	  }
 	};
-      
+
       ++pos;
     };
 
@@ -2103,12 +2103,12 @@ cmp_nocase_partial(const string& s, const string& s2)
 
 }
 
-/* closeall() - close all FDs >= a specified value */ 
-void closeall(int fd) 
+/* closeall() - close all FDs >= a specified value */
+void closeall(int fd)
 {
-	int fdlimit = sysconf(_SC_OPEN_MAX); 
-	while (fd < fdlimit) 
-		close(fd++); 
+	int fdlimit = sysconf(_SC_OPEN_MAX);
+	while (fd < fdlimit)
+		close(fd++);
 }
 
 void parse_networklist(char *string, struct networklist *list)
@@ -2131,7 +2131,7 @@ void parse_networklist(char *string, struct networklist *list)
 		if (inet_pton(AF_INET, tnet, &net))
 		{
 			struct in_addr mask;
-			
+
 			if (tmask)
 			{
 				if (strchr(tmask, '.') == NULL)
@@ -2168,7 +2168,7 @@ void parse_networklist(char *string, struct networklist *list)
 		} else if (inet_pton(AF_INET6, tnet, &net6))
 		{
 			int mask;
-			
+
 			if (tmask)
 			{
 				if (sscanf(tmask, "%d", &mask) != 1 || mask > 128)
@@ -2178,7 +2178,7 @@ void parse_networklist(char *string, struct networklist *list)
 				}
 			} else
 				mask = 128;
-			
+
 			list->nets[list->num_nets].net6.af = AF_INET6;
 			list->nets[list->num_nets].net6.network = net6;
 			list->nets[list->num_nets].net6.netmask = mask;
@@ -2199,14 +2199,14 @@ int ip_in_networklist(struct sockaddr *addr, struct networklist *list)
 
 	if (list->num_nets == 0)
 		return 0;
-	
+
 	//debug(D_NET, "Checking %s against:", inet_ntoa(ip));
 	for (i = 0; i < list->num_nets; i++)
 	{
 		if (list->nets[i].net.af == AF_INET && addr->sa_family == AF_INET)
 		{
 			struct in_addr ip = ((struct sockaddr_in *)addr)->sin_addr;
-			
+
 			debug(D_NET, "%s", inet_ntoa(list->nets[i].net4.network));
 			debug(D_NET, "/%s", inet_ntoa(list->nets[i].net4.netmask));
 			if ((ip.s_addr & list->nets[i].net4.netmask.s_addr) == list->nets[i].net4.network.s_addr)
@@ -2218,18 +2218,18 @@ int ip_in_networklist(struct sockaddr *addr, struct networklist *list)
 		{
 			u_int8_t *ip = ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr;
 			int mask, j;
-			
+
 			mask = list->nets[i].net6.netmask;
 			for (j = 0; j < 16 && mask > 0; j++, mask -= 8)
 			{
 				unsigned char bytemask;
-				
+
 				bytemask = (mask < 8) ? ~((1L << (8 - mask)) - 1) : 0xff;
-				
+
 				if ((ip[j] & bytemask) != (list->nets[i].net6.network.s6_addr[j] & bytemask))
 					break;
 			}
-			
+
 			if (mask <= 0)
 			{
 				debug(D_NET, "Hit!");
@@ -2281,7 +2281,7 @@ FILE *popenv(char *const argv[], const char *type, pid_t *pid)
 	if (pipe(pdes) < 0)
 		return (NULL);
 	switch (*pid = fork()) {
-	
+
 	case -1:			/* Error. */
 		save_errno = errno;
 		(void)close(pdes[0]);
@@ -2304,7 +2304,7 @@ FILE *popenv(char *const argv[], const char *type, pid_t *pid)
 			(void)dup2(pdes[1], STDERR_FILENO);
 			if (pdes[1] != STDOUT_FILENO && pdes[1] != STDERR_FILENO) {
 				(void)close(pdes[1]);
-			} 
+			}
 		} else {
 			if (pdes[0] != STDIN_FILENO) {
 				(void)dup2(pdes[0], STDIN_FILENO);

--- a/spamass-milter.h
+++ b/spamass-milter.h
@@ -83,6 +83,12 @@ struct networklist
 	int num_nets;
 };
 
+/* an array of addresses */
+struct addresslist
+{
+        char **addrs;
+        int num_addrs;
+};
 
 // Debug tokens.
 enum debuglevel
@@ -199,6 +205,8 @@ int cmp_nocase_partial(const string&, const string&);
 void closeall(int fd);
 void parse_networklist(char *string, struct networklist *list);
 int ip_in_networklist(struct sockaddr *addr, struct networklist *list);
+void parse_addresslist(char *string, struct addresslist *list);
+int addr_in_addresslist(char *addr, struct addresslist *list);
 void parse_debuglevel(char* string);
 char *strlwr(char *str);
 void warnmacro(const char *macro, const char *scope);

--- a/spamass-milter.h
+++ b/spamass-milter.h
@@ -5,19 +5,19 @@
 //  Main include file for SpamAss-Milter
 //
 //  Copyright (c) 2002 Georg C. F. Greve <greve@gnu.org>,
-//   all rights maintained by FSF Europe e.V., 
+//   all rights maintained by FSF Europe e.V.,
 //   Villa Vogelsang, Antonienallee 1, 45279 Essen, Germany
 //
 //   This program is free software; you can redistribute it and/or modify
 //   it under the terms of the GNU General Public License as published by
 //   the Free Software Foundation; either version 2 of the License, or
 //   (at your option) any later version.
-//  
+//
 //   This program is distributed in the hope that it will be useful,
 //   but WITHOUT ANY WARRANTY; without even the implied warranty of
 //   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //   GNU General Public License for more details.
-//  
+//
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
 //   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -85,7 +85,7 @@ struct networklist
 
 
 // Debug tokens.
-enum debuglevel 
+enum debuglevel
 {
 	D_ALWAYS, D_FUNC, D_POLL, D_UORI, D_STR, D_MISC, D_NET, D_SPAMC, D_RCPT,
 	D_COPY,
@@ -138,7 +138,7 @@ private:
   void empty_and_close_pipe();
   int read_pipe();
 
-public:  
+public:
   // flags
   bool error;
   bool running;		/* XXX merge running, connected, and pid */
@@ -154,11 +154,11 @@ public:
   // Variables for SpamAssassin influenced fields
   string x_spam_status, x_spam_flag, x_spam_report, x_spam_prev_content_type;
   string x_spam_checker_version, x_spam_level, _content_type, _subject;
-  
+
   // Envelope info: MAIL FROM:, RCPT TO:, and IP address of remote host
   // _rcpt only holds the first recipient if there are more than one
   string _from, _rcpt, _connectip;
-  
+
   // Counter to keep track of the number of recipients
   int    _numrcpt;
 
@@ -172,7 +172,7 @@ public:
   pid_t pid;
   int pipe_io[2][2];
 };
-  
+
 /* Private data structure to carry per-client data between calls */
 struct context
 {
@@ -189,7 +189,7 @@ struct context
 /* This hack is the only way to call pointers to member functions! */
 typedef string::size_type (SpamAssassin::*t_setter)(const string &val);
 #define callsetter(object, ptrToMember)  ((object).*(ptrToMember))
-       
+
 int assassinate(SMFICTX*, SpamAssassin*);
 
 void throw_error(const string&);


### PR DESCRIPTION
I have added a feature that allows specifying a list of addresses which will be exempt from scanning.  This is useful for certain recipients that need to receive all messages regardless of content.  Typically this is special purpose accounts such as abuse@example.com or other internal-use addresses.

P.S. Sorry about all the changes due to whitespace-only edits.  I tried 3 different editors and no matter what I did, I still ended up with these extra "differences" in the end.  As such I was able to least made separate commits for whitespace vs. actual code changes.