### PR TITLE
Allow tempfails

### DIFF
--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -17,6 +17,7 @@
 .Op Fl f
 .Op Fl g Ar group
 .Op Fl i Ar networks
+.Op Fl l Ar nn
 .Op Fl m
 .Op Fl M
 .Op Fl P Ar pidfile
@@ -140,6 +141,10 @@ Multiple
 flags will append to the list.
 For example, if you list all your internal networks, no outgoing emails
 will be filtered.
+.It Fl l Ar nn
+Randomly defer scanned email if it greater than or equal to
+.Ar nn . The probability of defering increases with the spam score. 
+Requires .Fl r as an upper limit. 
 .It Fl m
 Disables modification of the 
 .Ql Subject: 
@@ -191,9 +196,6 @@ a separate folder just in case of false positives, you can use
 .Fl r Ar 15
 and reject flagrant spam outright while still receiving low-scoring
 messages.
-.It Fl l Ar nn
-Randomly defer scanned email if it greater than or equal to
-.Ar nn . The probability of defering increases with the spam score.
 .It Fl R Ar rejecttext
 Mail that is rejected is rejected with the message "Blocked by SpamAssassin".
 This option allows the user to call with a different message, instead.   See

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -74,12 +74,14 @@ Mail that is rejected is rejected by default with a 550 returncode.  This option
 allows that to be overridden.  See also 
 .Fl C
 and
-.Fl R
+.Fl R .
 .It Fl C Ar rejectcode
 Mail that is rejected is rejected by default with a 5.7.1 code.  This option
 allows that to be overridden.  See also 
 .Fl R
-option.
+and
+.Fl c
+.
 .It Fl d Ar debugflags
 Enables logging. 
 .Ar debugflags 
@@ -155,8 +157,8 @@ For example, if you list all your internal networks, no outgoing emails
 will be filtered.
 .It Fl l Ar nn
 Randomly defer scanned email if it greater than or equal to
-.Ar nn
-. The probability of defering increases with the spam score. 
+.Ar nn .
+The probability of defering increases with the spam score. 
 Requires 
 .Fl r
 as an upper limit. 

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -9,6 +9,7 @@
 .Nm
 .Fl p Ar socket
 .Op Fl a
+.Op Fl A
 .Op Fl b Ns | Ns Fl B Ar spamaddress
 .Op Fl C Ar rejectcode
 .Op Fl d Ar debugflags
@@ -46,6 +47,9 @@ unmiltered, depending on the parameters in
 .Nm sendmail Ns 's .cf file.
 .It Fl a
 Skips messages received on an authenticated connection.
+.It Fl A
+Always scan and tag messages but treat .Fl T , .Fl i and .Fl a as an exception
+from rejecting and defering mails classified as spam.
 .It Fl b Ar spamaddress
 Redirects tagged spam to the specified email address.
 All envelope recipients are removed, and inserted into the message as

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -11,6 +11,7 @@
 .Op Fl a
 .Op Fl A
 .Op Fl b Ns | Ns Fl B Ar spamaddress
+.Op Fl c Ar returncode
 .Op Fl C Ar rejectcode
 .Op Fl d Ar debugflags
 .Op Fl D Ar host

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -191,6 +191,9 @@ a separate folder just in case of false positives, you can use
 .Fl r Ar 15
 and reject flagrant spam outright while still receiving low-scoring
 messages.
+.It Fl l Ar nn
+Randomly defer scanned email if it greater than or equal to
+.Ar nn . The probability of defering increases with the spam score.
 .It Fl R Ar rejecttext
 Mail that is rejected is rejected with the message "Blocked by SpamAssassin".
 This option allows the user to call with a different message, instead.   See

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -59,6 +59,9 @@ Only one of
 and
 .Fl B
 may be used.
+.It Fl c Ar returncode
+Mail that is rejected is rejected by default with a 550 returncode.  This option
+allows that to be overridden.  See also, -C and -R
 .It Fl C Ar rejectcode
 Mail that is rejected is rejected by default with a 5.7.1 code.  This option
 allows that to be overridden.  See also, -R

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -48,8 +48,13 @@ unmiltered, depending on the parameters in
 .It Fl a
 Skips messages received on an authenticated connection.
 .It Fl A
-Always scan and tag messages but treat .Fl T , .Fl i and .Fl a as an exception
-from rejecting and defering mails classified as spam.
+Always scan and tag messages but treat 
+.Fl T
+, 
+.Fl i
+and
+.Fl a
+as an exception from rejecting and defering mails classified as spam.
 .It Fl b Ar spamaddress
 Redirects tagged spam to the specified email address.
 All envelope recipients are removed, and inserted into the message as
@@ -66,11 +71,14 @@ and
 may be used.
 .It Fl c Ar returncode
 Mail that is rejected is rejected by default with a 550 returncode.  This option
-allows that to be overridden.  See also, -C and -R
+allows that to be overridden.  See also 
+.Fl C
+and
+.Fl R
 .It Fl C Ar rejectcode
 Mail that is rejected is rejected by default with a 5.7.1 code.  This option
-allows that to be overridden.  See also, -R
-.Fl S
+allows that to be overridden.  See also 
+.Fl R
 option.
 .It Fl d Ar debugflags
 Enables logging. 
@@ -147,8 +155,11 @@ For example, if you list all your internal networks, no outgoing emails
 will be filtered.
 .It Fl l Ar nn
 Randomly defer scanned email if it greater than or equal to
-.Ar nn . The probability of defering increases with the spam score. 
-Requires .Fl r as an upper limit. 
+.Ar nn
+. The probability of defering increases with the spam score. 
+Requires 
+.Fl r
+as an upper limit. 
 .It Fl m
 Disables modification of the 
 .Ql Subject: 

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -48,8 +48,13 @@ unmiltered, depending on the parameters in
 .It Fl a
 Skips messages received on an authenticated connection.
 .It Fl A
-Always scan and tag messages but treat .Fl T , .Fl i and .Fl a as an exception
-from rejecting and defering mails classified as spam.
+Always scan and tag messages but treat 
+.Fl T
+, 
+.Fl i
+and
+.Fl a
+as an exception from rejecting and defering mails classified as spam.
 .It Fl b Ar spamaddress
 Redirects tagged spam to the specified email address.
 All envelope recipients are removed, and inserted into the message as
@@ -66,12 +71,17 @@ and
 may be used.
 .It Fl c Ar returncode
 Mail that is rejected is rejected by default with a 550 returncode.  This option
-allows that to be overridden.  See also, -C and -R
+allows that to be overridden.  See also 
+.Fl C
+and
+.Fl R .
 .It Fl C Ar rejectcode
 Mail that is rejected is rejected by default with a 5.7.1 code.  This option
-allows that to be overridden.  See also, -R
-.Fl S
-option.
+allows that to be overridden.  See also 
+.Fl R
+and
+.Fl c
+.
 .It Fl d Ar debugflags
 Enables logging. 
 .Ar debugflags 
@@ -147,8 +157,11 @@ For example, if you list all your internal networks, no outgoing emails
 will be filtered.
 .It Fl l Ar nn
 Randomly defer scanned email if it greater than or equal to
-.Ar nn . The probability of defering increases with the spam score. 
-Requires .Fl r as an upper limit. 
+.Ar nn .
+The probability of defering increases with the spam score. 
+Requires 
+.Fl r
+as an upper limit. 
 .It Fl m
 Disables modification of the 
 .Ql Subject: 

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -10,7 +10,7 @@
 .Fl p Ar socket
 .Op Fl a
 .Op Fl b Ns | Ns Fl B Ar spamaddress
-.Op Fl C rejectcode
+.Op Fl C Ar rejectcode
 .Op Fl d Ar debugflags
 .Op Fl D Ar host
 .Op Fl e Ar defaultdomain

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -17,6 +17,7 @@
 .Op Fl f
 .Op Fl g Ar group
 .Op Fl i Ar networks
+.Op Fl l Ar nn
 .Op Fl m
 .Op Fl M
 .Op Fl P Ar pidfile
@@ -140,6 +141,10 @@ Multiple
 flags will append to the list.
 For example, if you list all your internal networks, no outgoing emails
 will be filtered.
+.It Fl l Ar nn
+Randomly defer scanned email if it greater than or equal to
+.Ar nn . The probability of defering increases with the spam score. 
+Requires .Fl r as an upper limit. 
 .It Fl m
 Disables modification of the 
 .Ql Subject: 

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -602,6 +602,7 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 			}
 		}
 		
+		if (do_reject && reject_reply_code[0]==52) return SMFIS_TEMPFAIL; // 4xx
 		if (do_reject) return SMFIS_REJECT;
                 if (do_defer) return SMFIS_TEMPFAIL;
 	}

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -90,6 +90,7 @@
 #include <errno.h>
 #include <netdb.h>
 #include <grp.h>
+#include <time.h>
 
 // C++ includes
 #include <cstdio>
@@ -158,7 +159,9 @@ const char *const debugstrings[] = {
 
 int flag_debug = (1<<D_ALWAYS);
 bool flag_reject = false;
+bool flag_random_defer = false;
 int reject_score = -1;
+int random_defer_score = -1;
 bool dontmodifyspam = false;    // Don't modify/add body or spam results headers
 bool dontmodify = false;        // Don't add SA headers, ever.
 bool flag_sniffuser = false;
@@ -169,6 +172,8 @@ char *spamdhost;
 char *rejecttext = NULL;				/* If we reject a mail, then use this text */
 char *rejectcode = NULL;				/* If we reject a mail, then use code */
 char *reject_reply_code = NULL;				/* If we reject a mail, then use smtp code */
+char *defercode = NULL;				/* If we reject a mail, then use code */
+char *defer_reply_code = NULL;				/* If we reject a mail, then use smtp code */
 struct networklist ignorenets;
 struct addresslist ignoreaddrs;
 int spamc_argc;
@@ -187,7 +192,7 @@ int
 main(int argc, char* argv[])
 {
    int c, err = 0;
-   const char *args = "afd:mMp:P:r:u:D:i:b:B:e:xS:R:c:C:g:T:";
+   const char *args = "afd:mMp:P:r:l:u:D:i:b:B:e:xS:R:c:C:g:T:";
    char *sock = NULL;
    char *group = NULL;
    bool dofork = false;
@@ -245,6 +250,10 @@ main(int argc, char* argv[])
             case 'r':
                 flag_reject = true;
                 reject_score = atoi(optarg);
+                break;
+            case 'l':
+                flag_random_defer = true;
+                random_defer_score = atoi(optarg);
                 break;
             case 'S':
                 path_to_sendmail = strdup(optarg);
@@ -334,6 +343,8 @@ main(int argc, char* argv[])
       cout << "   -P pidfile: Put processid in pidfile" << endl;
       cout << "   -r nn: reject messages with a score >= nn with an SMTP error.\n"
               "          use -1 to reject any messages tagged by SA." << endl;
+      cout << "   -l nn: randomly defer messages with a score >= nn with an non permanent SMTP error.\n"
+              "      Please be aware this will increase load." << endl;
       cout << "   -R RejectText: using this Reject Text." << endl;
       cout << "   -u defaultuser: pass the recipient's username to spamc.\n"
               "          Uses 'defaultuser' if there are multiple recipients." << endl;
@@ -356,6 +367,8 @@ main(int argc, char* argv[])
     if (reject_reply_code == NULL) {
         reject_reply_code = strdup ("550");
     }
+    defercode=to_nonpermanent(rejectcode);
+    defer_reply_code=to_nonpermanent(reject_reply_code);
 
     if (pidfilename)
     {
@@ -501,6 +514,7 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
   if (flag_reject)
   {
 	bool do_reject = false;
+        bool do_defer = false;
 	if (reject_score == -1 && !assassin->spam_flag().empty())
 		do_reject = true;
 	if (reject_score != -1)
@@ -521,12 +535,31 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 			debug(D_MISC, "SA score: %d", score);
 			if (score >= reject_score)
 				do_reject = true;
+                        if(flag_random_defer && score >= random_defer_score){
+                                int random_number, random_mod;
+                                srand ( time(NULL) );
+                                random_mod=score*4-3*random_defer_score-2;
+                                if(random_mod>2){
+                                        random_number = rand() % random_mod;
+                                }else{
+                                        random_number = 0;
+                                }
+                                debug(D_MISC, "Random mod=%d, num=%d", random_mod, random_number);
+                                if(random_number!=0){
+                                        do_defer = true;
+                                }
+                        }
 		}
 	}
-	if (do_reject)
+	if (do_reject || do_defer)
 	{
-		debug(D_MISC, "Rejecting");
-		smfi_setreply(ctx, const_cast<char*>(reject_reply_code), rejectcode, rejecttext);
+                if(do_defer){
+                        debug(D_MISC, "Defering");
+                        smfi_setreply(ctx, const_cast<char*>(defer_reply_code), defercode, rejecttext);
+                }else{
+                        debug(D_MISC, "Rejecting");
+                        smfi_setreply(ctx, const_cast<char*>(reject_reply_code), rejectcode, rejecttext);
+                }
 
 
 		if (flag_bucket)
@@ -2417,6 +2450,17 @@ FILE *popenv(char *const argv[], const char *type, pid_t *pid)
 	}
 
 	return (iop);
+}
+
+// {{{ convert status to nonpermant
+
+//
+// Replace the first char of a string to convert a status to nonpermanent
+char*
+to_nonpermanent(char* instring)
+{
+  char retstring=strdup(instring);
+  retstring[0]=52; // 4
 }
 
 // }}}

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -566,10 +566,10 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 	if (do_reject || do_defer)
 	{
                 if(do_defer){
-                        debug(D_MISC, "Defering");
+                        debug(D_ALWAYS, "Defering with %s %s: %s",const_cast<char*>(defer_reply_code), defercode, rejecttext);
                         smfi_setreply(ctx, const_cast<char*>(defer_reply_code), defercode, rejecttext);
                 }else{
-                        debug(D_MISC, "Rejecting");
+                        debug(D_ALWAYS, "Rejecting with %s %s: %s",const_cast<char*>(reject_reply_code), rejectcode, rejecttext);
                         smfi_setreply(ctx, const_cast<char*>(reject_reply_code), rejectcode, rejecttext);
                 }
 

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -2459,8 +2459,9 @@ FILE *popenv(char *const argv[], const char *type, pid_t *pid)
 char*
 to_nonpermanent(char* instring)
 {
-  char retstring=strdup(instring);
+  char* retstring=strdup(instring);
   retstring[0]=52; // 4
+  return(retstring);
 }
 
 // }}}

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -601,7 +601,10 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 				waitpid(pid, NULL, 0);
 			}
 		}
-		return SMFIS_REJECT;
+		
+		if (do_reject && reject_reply_code[0]==52) return SMFIS_TEMPFAIL; // 4xx
+		if (do_reject) return SMFIS_REJECT;
+                if (do_defer) return SMFIS_TEMPFAIL;
 	}
   }
 

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -601,7 +601,9 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 				waitpid(pid, NULL, 0);
 			}
 		}
-		return SMFIS_REJECT;
+		
+		if (do_reject) return SMFIS_REJECT;
+                if (do_defer) return SMFIS_TEMPFAIL;
 	}
   }
 

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -2452,12 +2452,10 @@ FILE *popenv(char *const argv[], const char *type, pid_t *pid)
 	return (iop);
 }
 
-// {{{ convert status to nonpermant
-
+// convert status to nonpermant
 //
 // Replace the first char of a string to convert a status to nonpermanent
-char*
-to_nonpermanent(char* instring)
+char *to_nonpermanent(char* instring)
 {
   char* retstring=strdup(instring);
   retstring[0]=52; // 4

--- a/spamass-milter.h
+++ b/spamass-milter.h
@@ -211,5 +211,6 @@ void parse_debuglevel(char* string);
 char *strlwr(char *str);
 void warnmacro(const char *macro, const char *scope);
 FILE *popenv(char *const argv[], const char *type, pid_t *pid);
+char *to_nonpermanent(char* instring);
 
 #endif

--- a/spamass-milter.h
+++ b/spamass-milter.h
@@ -189,6 +189,7 @@ struct context
 	char *queueid;
 	char *auth_authen;
 	char *auth_ssf;
+        bool onlytag;
 	SpamAssassin *assassin; // pointer to the SA object if we're processing a message
 };
 


### PR DESCRIPTION
Hi,

I've added some features to allow non permanent rejecting (tempfail). The main feature of this is the -l <LowerLimit>, which also allows to randomly delay based on the spam limit. The probability of getting rejected increases with the spam limit.
Another Feature is the -A flag which allows to always process the message though spamassassin but only to tag (not reject or defer) if the -i or -T matches.

Please have a look at this.

Kind regards,
    Lars