### PR TITLE
Allow tempfails (in a more digestible way)

### DIFF
--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -10,7 +10,8 @@
 .Fl p Ar socket
 .Op Fl a
 .Op Fl b Ns | Ns Fl B Ar spamaddress
-.Op Fl C rejectcode
+.Op Fl c Ar returncode
+.Op Fl C Ar rejectcode
 .Op Fl d Ar debugflags
 .Op Fl D Ar host
 .Op Fl e Ar defaultdomain
@@ -59,11 +60,19 @@ Only one of
 and
 .Fl B
 may be used.
+.It Fl c Ar returncode
+Mail that is rejected is rejected by default with a 550 returncode.  This option
+allows that to be overridden.  See also 
+.Fl C
+and
+.Fl R .
 .It Fl C Ar rejectcode
 Mail that is rejected is rejected by default with a 5.7.1 code.  This option
-allows that to be overridden.  See also, -R
-.Fl S
-option.
+allows that to be overridden.  See also 
+.Fl R
+and
+.Fl c
+.
 .It Fl d Ar debugflags
 Enables logging. 
 .Ar debugflags 

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -18,6 +18,7 @@
 .Op Fl f
 .Op Fl g Ar group
 .Op Fl i Ar networks
+.Op Fl l Ar nn
 .Op Fl m
 .Op Fl M
 .Op Fl P Ar pidfile
@@ -146,6 +147,13 @@ Multiple
 flags will append to the list.
 For example, if you list all your internal networks, no outgoing emails
 will be filtered.
+.It Fl l Ar nn
+Randomly defer scanned email if it greater than or equal to
+.Ar nn .
+The probability of defering increases with the spam score. 
+Requires 
+.Fl r
+as an upper limit. 
 .It Fl m
 Disables modification of the 
 .Ql Subject: 

--- a/spamass-milter.1.in
+++ b/spamass-milter.1.in
@@ -9,6 +9,7 @@
 .Nm
 .Fl p Ar socket
 .Op Fl a
+.Op Fl A
 .Op Fl b Ns | Ns Fl B Ar spamaddress
 .Op Fl c Ar returncode
 .Op Fl C Ar rejectcode
@@ -47,6 +48,14 @@ unmiltered, depending on the parameters in
 .Nm sendmail Ns 's .cf file.
 .It Fl a
 Skips messages received on an authenticated connection.
+.It Fl A
+Always scan and tag messages but treat 
+.Fl T
+, 
+.Fl i
+and
+.Fl a
+as an exception from rejecting and defering mails classified as spam.
 .It Fl b Ar spamaddress
 Redirects tagged spam to the specified email address.
 All envelope recipients are removed, and inserted into the message as

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -185,6 +185,7 @@ bool flag_full_email = false;		/* pass full email address to spamc */
 bool flag_expand = false;	/* alias/virtusertable expansion */
 bool warnedmacro = false;	/* have we logged that we couldn't fetch a macro? */
 bool auth = false;		/* don't scan authenticated users */
+bool alwaystag = false;
 
 // {{{ main()
 
@@ -192,7 +193,7 @@ int
 main(int argc, char* argv[])
 {
    int c, err = 0;
-   const char *args = "afd:mMp:P:r:l:u:D:i:b:B:e:xS:R:c:C:g:T:";
+   const char *args = "aAfd:mMp:P:r:l:u:D:i:b:B:e:xS:R:c:C:g:T:";
    char *sock = NULL;
    char *group = NULL;
    bool dofork = false;
@@ -211,6 +212,9 @@ main(int argc, char* argv[])
         switch (c) {
             case 'a':
                 auth = true;
+                break;
+            case 'A':
+                alwaystag = true;
                 break;
             case 'f':
                 dofork = true;
@@ -320,7 +324,7 @@ main(int argc, char* argv[])
       cout << "SpamAssassin Sendmail Milter Plugin" << endl;
       cout << "Usage: spamass-milter -p socket [-b|-B bucket] [-d xx[,yy...]] [-D host]" << endl;
       cout << "                      [-e defaultdomain] [-f] [-i networks] [-m] [-M]" << endl;
-      cout << "                      [-P pidfile] [-r nn] [-u defaultuser] [-x] [-a]" << endl;
+      cout << "                      [-P pidfile] [-r nn] [-u defaultuser] [-x] [-a] [-A]" << endl;
       cout << "                      [-T addresses]" << endl;
       cout << "                      [-c RejectRepyCode] [-C rejectcode] [-R rejectmsg] [-g group]" << endl;
       cout << "                      [-- spamc args ]" << endl;
@@ -350,6 +354,7 @@ main(int argc, char* argv[])
               "          Uses 'defaultuser' if there are multiple recipients." << endl;
       cout << "   -x: pass email address through alias and virtusertable expansion." << endl;
       cout << "   -a: don't scan messages over an authenticated connection." << endl;
+      cout << "   -A: Scan but only tag messages affected by -a, -T and -i, never reject or defer them." << endl;
       cout << "   -T: skip (ignore) checks if any recipient is in this address list" << endl;
       cout << "          example: -T foo@bar.com,spamlover@yourdomain.com" << endl;
       cout << "   -- spamc args: pass the remaining flags to spamc." << endl;
@@ -496,6 +501,7 @@ void update_or_insert(SpamAssassin* assassin, SMFICTX* ctx, string oldstring, t_
 int
 assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 {
+  struct context *sctx = (struct context*)smfi_getpriv(ctx);
   // find end of header (eol in last line of header)
   // and beginning of body
   string::size_type eoh1 = assassin->d().find("\n\n");
@@ -551,6 +557,12 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
                         }
 		}
 	}
+	if(sctx->onlytag){
+                debug(D_MISC, "We should only tag this message.");
+                do_reject=false;
+                do_defer=false;
+        }
+	
 	if (do_reject || do_defer)
 	{
                 if(do_defer){
@@ -777,6 +789,7 @@ mlfi_connect(SMFICTX * ctx, char *hostname, _SOCK_ADDR * hostaddr)
 	sctx->queueid = NULL;
 	sctx->auth_authen = NULL;
 	sctx->auth_ssf = NULL;
+        sctx->onlytag=false;
 
 	/* store our FQDN */
 	macro_j = smfi_getsymval(ctx, const_cast<char *>("j"));
@@ -811,8 +824,11 @@ mlfi_connect(SMFICTX * ctx, char *hostname, _SOCK_ADDR * hostaddr)
 	{
 		debug(D_NET, "%s is in our ignore list - accepting message",
 		      sctx->connect_ip);
-		debug(D_FUNC, "mlfi_connect: exit ignore");
-		return SMFIS_ACCEPT;
+                sctx->onlytag=true;
+                if(!alwaystag){
+                      debug(D_FUNC, "mlfi_connect: exit ignore");
+                      return SMFIS_ACCEPT;
+                }
 	}
 
 	// Tell Milter to continue
@@ -862,7 +878,11 @@ mlfi_envfrom(SMFICTX* ctx, char** envfrom)
 
     if (auth_type) {
       debug(D_MISC, "auth_type=%s", auth_type);
-      return SMFIS_ACCEPT;
+      sctx->onlytag=true;
+      if(!alwaystag){
+        debug(D_FUNC, "mlfi_envfrom: auth exit ignore");
+        return SMFIS_ACCEPT;
+      }
     }
   }
 
@@ -947,8 +967,11 @@ mlfi_envrcpt(SMFICTX* ctx, char** envrcpt)
    if (addr_in_addresslist(envrcpt[0], &ignoreaddrs))
    {
       debug(D_RCPT, "%s is in our ignore addrlist - accepting message", envrcpt[0]);
-      debug(D_FUNC, "mlfi_envrcpt: exit ignore");
-      return SMFIS_ACCEPT;
+      sctx->onlytag=true;
+      if(!alwaystag){
+        debug(D_FUNC, "mlfi_envrcpt: exit ignore");
+        return SMFIS_ACCEPT;
+      }
    }
 
 	if (flag_expand)

--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -168,6 +168,7 @@ char *path_to_sendmail = (char *) SENDMAIL;
 char *spamdhost;
 char *rejecttext = NULL;				/* If we reject a mail, then use this text */
 char *rejectcode = NULL;				/* If we reject a mail, then use code */
+char *reject_reply_code = NULL;				/* If we reject a mail, then use smtp code */
 struct networklist ignorenets;
 struct addresslist ignoreaddrs;
 int spamc_argc;
@@ -186,7 +187,7 @@ int
 main(int argc, char* argv[])
 {
    int c, err = 0;
-   const char *args = "afd:mMp:P:r:u:D:i:b:B:e:xS:R:C:g:T:";
+   const char *args = "afd:mMp:P:r:u:D:i:b:B:e:xS:R:c:C:g:T:";
    char *sock = NULL;
    char *group = NULL;
    bool dofork = false;
@@ -247,6 +248,9 @@ main(int argc, char* argv[])
                 break;
             case 'S':
                 path_to_sendmail = strdup(optarg);
+                break;
+            case 'c':
+                reject_reply_code = strdup (optarg);
                 break;
             case 'C':
                 rejectcode = strdup (optarg);
@@ -309,13 +313,14 @@ main(int argc, char* argv[])
       cout << "                      [-e defaultdomain] [-f] [-i networks] [-m] [-M]" << endl;
       cout << "                      [-P pidfile] [-r nn] [-u defaultuser] [-x] [-a]" << endl;
       cout << "                      [-T addresses]" << endl;
-      cout << "                      [-C rejectcode] [-R rejectmsg] [-g group]" << endl;
+      cout << "                      [-c RejectRepyCode] [-C rejectcode] [-R rejectmsg] [-g group]" << endl;
       cout << "                      [-- spamc args ]" << endl;
       cout << "   -p socket: path to create socket" << endl;
       cout << "   -b bucket: redirect spam to this mail address.  The orignal" << endl;
       cout << "          recipient(s) will not receive anything." << endl;
       cout << "   -B bucket: add this mail address as a BCC recipient of spam." << endl;
-      cout << "   -C RejectCode: using this Reject Code." << endl;
+      cout << "   -c RejectRepyCode: reject using this Reply Code (default 550)." << endl;
+      cout << "   -C RejectCode: using this Reject Code (default 5.7.1)." << endl;
       cout << "   -d xx[,yy ...]: set debug flags.  Logs to syslog" << endl;
       cout << "   -D host: connect to spamd at remote host (deprecated)" << endl;
       cout << "   -e defaultdomain: pass full email address to spamc instead of just\n"
@@ -347,6 +352,9 @@ main(int argc, char* argv[])
     }
     if (rejectcode == NULL) {
         rejectcode = strdup ("5.7.1");
+    }
+    if (reject_reply_code == NULL) {
+        reject_reply_code = strdup ("550");
     }
 
     if (pidfilename)
@@ -518,7 +526,7 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 	if (do_reject)
 	{
 		debug(D_MISC, "Rejecting");
-		smfi_setreply(ctx, const_cast<char*>("550"), rejectcode, rejecttext);
+		smfi_setreply(ctx, const_cast<char*>(reject_reply_code), rejectcode, rejecttext);
 
 
 		if (flag_bucket)
@@ -548,6 +556,8 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 				waitpid(pid, NULL, 0);
 			}
 		}
+		
+		if (reject_reply_code[0]==52) return SMFIS_TEMPFAIL; // 4xx
 		return SMFIS_REJECT;
 	}
   }

--- a/spamass-milter.h
+++ b/spamass-milter.h
@@ -211,5 +211,6 @@ void parse_debuglevel(char* string);
 char *strlwr(char *str);
 void warnmacro(const char *macro, const char *scope);
 FILE *popenv(char *const argv[], const char *type, pid_t *pid);
+char *to_nonpermanent(char* instring);
 
 #endif

--- a/spamass-milter.h
+++ b/spamass-milter.h
@@ -189,6 +189,7 @@ struct context
 	char *queueid;
 	char *auth_authen;
 	char *auth_ssf;
+        bool onlytag;
 	SpamAssassin *assassin; // pointer to the SA object if we're processing a message
 };
 


### PR DESCRIPTION
Hi,

this is thought to replace pull request #4 since I can't switch it to another branch.

I've split up the changes into the three features. They are in the order I added them since each of them is adding an element to args and from the first to the last it changes from
   const char *args = "afd:mMp:P:r:u:D:i:b:B:e:xS:R:C:g:T:";
to
   const char *args = "aAfd:mMp:P:r:l:u:D:i:b:B:e:xS:R:c:C:g:T:";
.

Otherwise the -A would option would be independent of that. The -c and the -l strongly interacct.

Putting this in this form together would make the changes better readable. The result is the same as requested in #4. During preparing this I found the misstake corrected in 9f779d31f1ff494a88039968d1f81c7f7038976. 

Oops, I've just seen you've just pulled this. Choose which would be  the better one. ;-)

Kind regards,
  Lars

