### PR TITLE
Fixing memory intialization issue in parse_addresslist.

### DIFF
--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -2333,7 +2333,7 @@ void parse_addresslist(char *string, struct addresslist *list)
    while ((token = strsep(&string, ", ")))
    {
       char *addr = (char *)malloc(strlen(token)+3);
-      addr = strcat(addr,"<");
+      addr = strcpy(addr,"<");
       addr = strcat(addr,token);
       addr = strcat(addr,">");
 


### PR DESCRIPTION
Hi Andy,

during further testing with a bit larger list of exception addresses I sometimes got weird chars in front of the pointet bracket in the logfile. During having a look at the memory allocation in parse_addresslist I found this issue.

Since space allocated for a string can't doesn't necessarily contain an empty string in C/C++ the first operation should be strcpy. If the space is allocated that way there is definitely no need for strncpy, when copying a constant single character string (0x3c, 0x00). ;-)

Otherwise (with the strcat) non zero characters at the beginning of the allocated memory will be treated as a part of the string, and this will cause memory corruptions during startup. This is not security critical since it only happens on startup.
This obviously got in with the relatively new -T Option and will not be triggered without using the -T Option, and it's not always triggered when calling spamass-milter with the -T option.

Kind regards,
   Lars