### PR TITLE
Support for RelayCountry header

### DIFF
--- a/spamass-milter.cpp
+++ b/spamass-milter.cpp
@@ -514,6 +514,7 @@ assassinate(SMFICTX* ctx, SpamAssassin* assassin)
 
   update_or_insert(assassin, ctx, assassin->spam_flag(), &SpamAssassin::set_spam_flag, "X-Spam-Flag");
   update_or_insert(assassin, ctx, assassin->spam_status(), &SpamAssassin::set_spam_status, "X-Spam-Status");
+  update_or_insert(assassin, ctx, assassin->spam_relay_country(), &SpamAssassin::set_spam_relay_country, "X-Spam-Relay-Country");
 
   /* Summarily reject the message if SA tagged it, or if we have a minimum
      score, reject if it exceeds that score. */
@@ -1194,8 +1195,9 @@ mlfi_header(SMFICTX* ctx, char* headerf, char* headerv)
     {
       int suppress = 1;
       // memorize content of old fields
-
-      if ( cmp_nocase_partial("X-Spam-Status", headerf) == 0 )
+      if ( cmp_nocase_partial("X-Spam-Relay-Country", headerf) == 0)
+        assassin->set_spam_relay_country(headerv);
+      else if ( cmp_nocase_partial("X-Spam-Status", headerf) == 0 )
 	assassin->set_spam_status(headerv);
       else if ( cmp_nocase_partial("X-Spam-Flag", headerf) == 0 )
 	assassin->set_spam_flag(headerv);
@@ -1762,6 +1764,13 @@ SpamAssassin::d()
 //
 // get values of the different SpamAssassin fields
 //
+
+string&
+SpamAssassin::spam_relay_country()
+{
+ return x_spam_relay_country;
+}
+
 string&
 SpamAssassin::spam_status()
 {
@@ -1882,6 +1891,14 @@ SpamAssassin::set_numrcpt(const int val)
 // set the values of the different SpamAssassin
 // fields in our element. Returns former size of field
 //
+string::size_type
+SpamAssassin::set_spam_relay_country(const string& val)
+{
+ string::size_type old = x_spam_relay_country.size();
+ x_spam_relay_country = val;
+ return (old);
+}
+
 string::size_type
 SpamAssassin::set_spam_status(const string& val)
 {

--- a/spamass-milter.h
+++ b/spamass-milter.h
@@ -111,7 +111,8 @@ public:
   void input();
 
   string& d();
-
+  
+  string& spam_relay_country();
   string& spam_status();
   string& spam_flag();
   string& spam_report();
@@ -128,6 +129,7 @@ public:
   int     numrcpt();	/* total RCPT TO: recpients */
   int     set_numrcpt();	/* increment total RCPT count */
   int     set_numrcpt(const int);	/* set total RCPT count to n */
+  string::size_type set_spam_relay_country(const string&);
   string::size_type set_spam_status(const string&);
   string::size_type set_spam_flag(const string&);
   string::size_type set_spam_report(const string&);
@@ -158,7 +160,7 @@ public:
   string outputbuffer;
 
   // Variables for SpamAssassin influenced fields
-  string x_spam_status, x_spam_flag, x_spam_report, x_spam_prev_content_type;
+  string x_spam_relay_country, x_spam_status, x_spam_flag, x_spam_report, x_spam_prev_content_type;
   string x_spam_checker_version, x_spam_level, _content_type, _subject;
 
   // Envelope info: MAIL FROM:, RCPT TO:, and IP address of remote host


### PR DESCRIPTION
Minimal changes to get the header from SA-CountryRelay plugin down the chain for further processing.